### PR TITLE
[AR/CS-003] Added consumption of City/state API on Home Compenent using vanilla js.

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,48 +1,45 @@
 
-     <div class="section no-pad-bot banner" id="index-banner">
-               <div class="container">
+     <div class="section no-pad-bot banner home" id="index-banner">
+               <div class="container home__c">
                  <br><br>
                  <h1 class="header center orange-text">Quer adotar?</h1>
                  <!--<div class="row center">
                    <h5 class="header col s12 light">A modern responsive front-end framework based on Material Design</h5>
                  </div>-->
                  
-                 <div class="">
-                   <form class="form-banner">
+                 <div class="home__c__w">
+                   <form class="form-banner home__c__w__form">
                        <div class="row">
-                       <div class="input-field col s12 m3" >
-                           <select class="browser-default">
+                       <div class="input-field col s12 m3 home__c__w__form__especie" >
+                           <select class="browser-default home__c__w__form__especie__select">
                              <option value="" >Espécie</option>
                              <option value="1">Gato</option>
                              <option value="2">Cachorro</option>
                              <option value="3">Outros</option>
                            </select>
                          </div>
-                         <div class="input-field col s12 m3">
-                             <select class="browser-default">
+                         <div class="input-field col s12 m3 home__c__w__form__porte">
+                             <select class="browser-default home__c__w__form__porte__select">
                                <option value="">Porte</option>
                                <option value="1">Pequeno</option>
                                <option value="2">Médio</option>
                                <option value="3">Grande</option>
                              </select>
-                           </div>
-                             <div class="input-field col s12 m3" >
-                                 <select class="browser-default">
-                                   <option value="" >Estado</option>
-                                   <option value="1">Bahia</option>
-                                   <option value="2">São Paulo</option>
-                                   <option value="3">Rio de Janeiro</option>
-                                 </select>
-                               </div>
-                               <div class="input-field col s12 m3">
-                                   <select class="browser-default">
-                                     <option value="">Cidade</option>
-                                     <option value="1">Option 1</option>
-                                     <option value="2">Option 2</option>
-                                     <option value="3">Option 3</option>
-                                   </select>
-                                 </div>
-                               </div> 
+                          </div>
+                          <div class="input-field col s12 m3 home__c__w__form__estado" >
+                              <select class="browser-default home__c__w__form__estado__select">
+                                <option value="" >Estado</option>
+                                <option value="1">Bahia</option>
+                                <option value="2">São Paulo</option>
+                                <option value="3">Rio de Janeiro</option>
+                              </select>
+                            </div>
+                            <div class="input-field col s12 m3 home__c__w__form__cidade">
+                                <select class="browser-default home__c__w__form__cidade__select disabled" disabled>
+                                  <option value="" disabled>Cidade</option>
+                                </select>
+                              </div>
+                          </div> 
                        <!--  <div class="row center">  
                              <label for="macho">
                                  <input class="with-gap white" name="sexo" id="macho" value="macho" type="radio"/>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -28,10 +28,7 @@
                           </div>
                           <div class="input-field col s12 m3 home__c__w__form__estado" >
                               <select class="browser-default home__c__w__form__estado__select">
-                                <option value="" >Estado</option>
-                                <option value="1">Bahia</option>
-                                <option value="2">São Paulo</option>
-                                <option value="3">Rio de Janeiro</option>
+                                <option value="" disabled>Estado</option>
                               </select>
                             </div>
                             <div class="input-field col s12 m3 home__c__w__form__cidade">

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -27,15 +27,18 @@ const HomeSingleton = {
   },
   loadStates: function() {
     let states_el = document.querySelector(".home__c__w__form__estado__select");
-    states_el.innerHTML = `<option value="" disabled selected>Estado</option>`;
+    states_el.disabled = true;
+    states_el.innerHTML = `<option value="" disabled selected>Carregando...</option>`;
     fetch(`${window.location.protocol}//${window.location.hostname}:3000/api/consulta/cidades`)
       .then(res => {
         return res.json()
       })
       .then(states => {
+        states_el.innerHTML = `<option value="" disabled selected>Estado</option>`;
         states.forEach(st => {
           states_el.innerHTML += `<option value=${st.sigla}>${st.nome}</option>`
         })
+        states_el.disabled = false;
       });
   },
   loadCities: function(state) {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -41,6 +41,7 @@ const HomeSingleton = {
   loadCities: function(state) {
     let cities_el = document.querySelector(".home__c__w__form__cidade__select")
     let cities_firstoption = document.querySelector(".home__c__w__form__cidade__select option");
+    cities_el.disabled = true;
     cities_firstoption.innerHTML = "Carregando...";
     fetch(`${window.location.protocol}//${window.location.hostname}:3000/api/consulta/cidades/${state}`)
     .then(res => {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -4,12 +4,55 @@ import { FormloginComponent } from './../usuarios/formlogin/formlogin.component'
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.css']
+  styleUrls: ['./home.component.css'],
 })
 export class HomeComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {
+    HomeSingleton.init();
   }
 
+}
+
+const HomeSingleton = {
+  init: function() {
+    this.addListeners();
+    this.loadStates();
+  },
+  addListeners: function() {
+    document.querySelector(".home__c__w__form__estado__select").addEventListener("change", e => {
+      this.loadCities(e.currentTarget.value);
+    }) 
+  },
+  loadStates: function() {
+    let states_el = document.querySelector(".home__c__w__form__estado__select");
+    states_el.innerHTML = `<option value="" disabled selected>Estado</option>`;
+    fetch(`${window.location.protocol}//${window.location.hostname}:3000/api/consulta/cidades`)
+      .then(res => {
+        return res.json()
+      })
+      .then(states => {
+        states.forEach(st => {
+          states_el.innerHTML += `<option value=${st.sigla}>${st.nome}</option>`
+        })
+      });
+  },
+  loadCities: function(state) {
+    let cities_el = document.querySelector(".home__c__w__form__cidade__select")
+    let cities_firstoption = document.querySelector(".home__c__w__form__cidade__select option");
+    cities_firstoption.innerHTML = "Carregando...";
+    fetch(`${window.location.protocol}//${window.location.hostname}:3000/api/consulta/cidades/${state}`)
+    .then(res => {
+      return res.json()
+    })
+    .then(cities => {
+      cities.forEach(ct => {
+        cities_el.innerHTML += `<option value=${ct}>${ct}</option>`
+      });
+      cities_firstoption = document.querySelector(".home__c__w__form__cidade__select option");
+      cities_firstoption.innerHTML = "Cidade";
+      cities_el.disabled = false;
+    });
+  }
 }


### PR DESCRIPTION
**O que**

- Implementação de consumo da API de consulta de cidades com base no estado.

**Antes**

- Select era estático e só mostrava mock data.

**Depois**

-  Adicionado script que carrega os estados e as cidades através de consumo da API 
-- ref.: CodeSolidario/pets_heroes_api#2

**Sumário de commits**

Added consumption of City/state API on Home Compenent using vanilla js.
5d52000

Amend: adding disabled on new loaded city. Fix #1.
8e803e6

Amend: removed mock data and added loading behaviour to state select.
a385d30 

**Como validar esse PR**

- Fazer pull da branch.
- Rodar `npm i` na pasta raíz do repositório.
- Visitar  https://localhost:{porta} e validar comportamento dos selects.


Assets e textos disponíveis no XD: N/A

**URLs afetadas**

-  https://localhost:{porta}